### PR TITLE
Add in function to get submitter name

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(change_submission_status)
 export(evaluation_queue_query)
+export(get_submitter_name)
 export(syn_login)
 import(dplyr)
 import(reticulate)

--- a/R/submission.R
+++ b/R/submission.R
@@ -27,3 +27,28 @@
 change_submission_status <- function(submissionid, status = "RECEIVED") {
   .change_submission_status(submissionid, status = status)
 }
+
+#' Wraps challengeutils.utils._get_submitter_name. Written for tests
+#'
+#' @param submitterid submitter id, can be a Synapse team or user Id.
+.get_submitter_name <- function(submitterid) {
+  get_submitter = challengeutils$utils$`_get_submitter_name`
+  get_submitter(syn = syn, submitterid = submitterid)
+}
+
+#' Gets the Synapse team name or username given a submitterid
+#'
+#' @param submitterid submitter id, can be a Synapse team or user Id.
+#'
+#' @return Team or User name
+#' @examples
+#' library(challengerutils)
+#' use_condaenv('challenge')
+#' syn_login()
+#' username <- get_submitter_name('3324230')
+#' teamname <- get_submitter_name('3377845')
+#' @import reticulate
+#' @export
+get_submitter_name <- function(submitterid) {
+  .get_submitter_name(submitterid)
+}

--- a/tests/testthat/test-submission.R
+++ b/tests/testthat/test-submission.R
@@ -8,3 +8,13 @@ test_that("Change Submmission tests", {
   expect_args(m, 1, 111, status = "SCORED")
   expect_equal(new_status, 100)
 })
+
+
+test_that("Get submitter name test", {
+  m = mock("username")
+  stub(get_submitter_name, '.get_submitter_name', m)
+  submitter_name = get_submitter_name(12345)
+  expect_called(m, 1)
+  expect_args(m, 1, 12345)
+  expect_equal(submitter_name, "username")
+})


### PR DESCRIPTION
- [x] fixes #9  (Link github issue if appropriate)
- [x] Did you run your tests locally (instructions [here](https://github.com/Sage-Bionetworks/challengerutils/blob/master/CONTRIBUTING.md)?
- [x] Did you add a good description about your changes or additions?

Gets the submitter's name from a team or user id.