### PR TITLE
remove syn object creation from zzz.R

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -3,7 +3,7 @@
 #' @param query A URI for evaluation queues (select * from evaluation_12345)
 .evaluation_queue_query <- function(query) {
   query_func <- challengeutils$utils$evaluation_queue_query
-  query_func(syn = syn, uri = query)
+  query_func(syn = .syn, uri = query)
 }
 
 #' Queries an evaluation queue for submissions

--- a/R/login.R
+++ b/R/login.R
@@ -8,5 +8,6 @@
 #' @import reticulate
 #' @export
 syn_login <- function(username = NULL, password = NULL){
+  syn <<- synapseclient$Synapse()
   syn$login(username, password)
 }

--- a/R/login.R
+++ b/R/login.R
@@ -8,6 +8,6 @@
 #' @import reticulate
 #' @export
 syn_login <- function(username = NULL, password = NULL){
-  syn <<- synapseclient$Synapse()
-  syn$login(username, password)
+  .syn <<- synapseclient$Synapse()
+  .syn$login(username, password)
 }

--- a/R/submission.R
+++ b/R/submission.R
@@ -6,7 +6,7 @@
 #' https://rest-docs.synapse.org/rest/org/sagebionetworks/evaluation/model/SubmissionStatusEnum.html
 .change_submission_status <- function(submissionid, status = "RECEIVED") {
   change_status <- challengeutils$utils$change_submission_status
-  change_status(syn = syn, submissionid = submissionid, status = status)
+  change_status(syn = .syn, submissionid = submissionid, status = status)
 }
 
 #' Changes a status of a submission

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,6 +9,5 @@ syn <- NULL
 
   #if synapseclient has not already been imported, do it
   synapseclient <<- reticulate::import('synapseclient', delay_load = T)
-  syn <<- synapseclient$Synapse()
-
+  
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,13 +1,18 @@
 challengeutils <- NULL
 synapseclient <- NULL
-syn <- NULL
 
 .onLoad <- function(libname, pkgname) {
 
-  #if challengeutils has not already been imported, do it
-  challengeutils <<- reticulate::import('challengeutils', delay_load = T)
+  syn_inst <- reticulate::py_module_available("synapseclient")
+  chal_inst <- reticulate::py_module_available("challengeutils")
 
-  #if synapseclient has not already been imported, do it
-  synapseclient <<- reticulate::import('synapseclient', delay_load = T)
-  
+  if(chal_inst){
+    challengeutils <<- reticulate::import('challengeutils', delay_load = T)
+  }
+
+  if(syn_inst){
+    synapseclient <<- reticulate::import('synapseclient', delay_load = T)
+  }
+
 }
+


### PR DESCRIPTION
- [x] fixes #19 (Link github issue if appropriate)
- [x] Did you run your tests locally (instructions [here](https://github.com/Sage-Bionetworks/challengerutils/blob/master/CONTRIBUTING.md)?
- [x] Did you add a good description about your changes or additions?

This fix moves the creation of `syn` out of .onLoad(), which was eliminating the benefit of using `delay_load` parameter of `reticulate::import()`. 

Logging in with `syn_login()` now creates a hidden object (`.syn`) which is available to the user to use synapseclient functions, and is also used by the other functions to pass back to the core python challengeutils functions. 